### PR TITLE
[FEATURE] Add possibility to configure custom sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ composer require --dev eliashaeussler/rector-config
 # rector.php
 
 use EliasHaeussler\RectorConfig\Config\Config;
+use EliasHaeussler\RectorConfig\Set\CustomSet;
 use Rector\Config\RectorConfig;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
+use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
     $config = Config::create($rectorConfig)->in(
@@ -43,6 +45,14 @@ return static function (RectorConfig $rectorConfig): void {
 
     // Include default Symfony sets
     $config->withSymfony();
+
+    // Include custom sets
+    $config->withSets(
+        new CustomSet(
+            SetList::CODE_QUALITY,
+            SetList::CODING_STYLE,
+        ),
+    );
 
     // Skip specific rectors
     $config->skip(

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -80,6 +80,15 @@ final class Config
         return $this;
     }
 
+    public function withSets(Set\Set ...$sets): self
+    {
+        foreach ($sets as $set) {
+            $this->sets[] = $set;
+        }
+
+        return $this;
+    }
+
     /**
      * @param non-empty-string ...$paths
      */

--- a/src/Set/CustomSet.php
+++ b/src/Set/CustomSet.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/rector-config".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\RectorConfig\Set;
+
+use function array_diff;
+use function array_filter;
+use function array_values;
+
+/**
+ * CustomSet.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class CustomSet implements Set
+{
+    /**
+     * @var array<string>
+     */
+    private array $sets = [];
+
+    public function __construct(string ...$sets)
+    {
+        $this->add(...$sets);
+    }
+
+    public function add(string ...$sets): self
+    {
+        $this->sets = [...$this->sets, ...array_filter($sets)];
+
+        return $this;
+    }
+
+    public function remove(string ...$sets): self
+    {
+        $this->sets = array_diff($this->sets, $sets);
+
+        return $this;
+    }
+
+    public function get(): array
+    {
+        return array_values($this->sets);
+    }
+}

--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -26,11 +26,13 @@ namespace EliasHaeussler\RectorConfig\Tests\Config;
 use EliasHaeussler\RectorConfig as Src;
 use EliasHaeussler\RectorConfig\Tests;
 use PHPUnit\Framework;
+use Rector\CodeQuality;
 use Rector\Config;
 use Rector\Core;
 use Rector\Php73;
 use Rector\Php74;
 use Rector\PHPUnit;
+use Rector\Set;
 use Rector\Symfony;
 
 /**
@@ -130,6 +132,25 @@ final class ConfigTest extends Framework\TestCase
 
         /* @see Symfony\Set\SymfonySetList::SYMFONY_CONSTRUCTOR_INJECTION */
         self::assertTrue($this->container?->has(Symfony\Rector\MethodCall\ContainerGetToConstructorInjectionRector::class));
+    }
+
+    #[Framework\Attributes\Test]
+    public function withSetsAddsCustomSetsToRectorConfig(): void
+    {
+        $this->createRectorConfig(
+            static function (Config\RectorConfig $rectorConfig) {
+                $subject = Src\Config\Config::create($rectorConfig);
+                $subject->withSets(
+                    new Src\Set\CustomSet(
+                        Set\ValueObject\SetList::CODE_QUALITY,
+                    ),
+                );
+                $subject->apply();
+            },
+        );
+
+        /* @see Set\ValueObject\SetList::CODE_QUALITY */
+        self::assertTrue($this->container?->has(CodeQuality\Rector\BooleanAnd\SimplifyEmptyArrayCheckRector::class));
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Set/CustomSetTest.php
+++ b/tests/src/Set/CustomSetTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/rector-config".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\RectorConfig\Tests\Set;
+
+use EliasHaeussler\RectorConfig as Src;
+use PHPUnit\Framework;
+
+/**
+ * CustomSetTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class CustomSetTest extends Framework\TestCase
+{
+    private Src\Set\CustomSet $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Src\Set\CustomSet('foo', 'baz');
+    }
+
+    #[Framework\Attributes\Test]
+    public function addAddsGivenSetsToCustomSet(): void
+    {
+        $this->subject->add('another foo', 'another baz');
+
+        $expected = [
+            'foo',
+            'baz',
+            'another foo',
+            'another baz',
+        ];
+
+        self::assertSame($expected, $this->subject->get());
+    }
+
+    #[Framework\Attributes\Test]
+    public function removeRemovesGivenSetsFromCustomSet(): void
+    {
+        $this->subject->remove('foo');
+
+        $expected = [
+            'baz',
+        ];
+
+        self::assertSame($expected, $this->subject->get());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReturnsConfiguredSets(): void
+    {
+        $expected = [
+            'foo',
+            'baz',
+        ];
+
+        self::assertSame($expected, $this->subject->get());
+    }
+}


### PR DESCRIPTION
With this PR, it is now possible to add custom Rectors sets to the `Config` object.