### PR TITLE
[FEATURE] Allow to skip specific paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ return static function (RectorConfig $rectorConfig): void {
         __DIR__.'/tests',
     );
 
+    // Skip specific paths
+    $config->not(
+        __DIR__.'/src/lib',
+        __DIR__.'/tests/test-application/vendor',
+    );
+
     // Include default PHPUnit sets
     $config->withPHPUnit();
 

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -45,6 +45,11 @@ final class Config
     private array $paths = [];
 
     /**
+     * @var list<non-empty-string>
+     */
+    private array $skipPaths = [];
+
+    /**
      * @var array<class-string<Core\Contract\Rector\RectorInterface>, list<non-empty-string>>
      */
     private array $skippedRectors = [
@@ -107,6 +112,16 @@ final class Config
     }
 
     /**
+     * @param non-empty-string ...$paths
+     */
+    public function not(string ...$paths): self
+    {
+        $this->skipPaths = array_values($paths);
+
+        return $this;
+    }
+
+    /**
      * @param class-string<Core\Contract\Rector\RectorInterface> $rector
      * @param list<non-empty-string>                             $paths
      */
@@ -135,7 +150,7 @@ final class Config
      */
     public function apply(): void
     {
-        $skip = [];
+        $skip = $this->skipPaths;
 
         // Transform skipped rectors for Rector config
         foreach ($this->skippedRectors as $skippedRector => $paths) {

--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -36,6 +36,8 @@ use Rector\Set;
 use Rector\Symfony;
 use Ssch\TYPO3Rector;
 
+use function count;
+
 /**
  * ConfigTest.
  *
@@ -181,6 +183,25 @@ final class ConfigTest extends Framework\TestCase
         );
 
         self::assertSame(['foo', 'baz'], $this->container?->getParameter(Core\Configuration\Option::PATHS));
+    }
+
+    #[Framework\Attributes\Test]
+    public function notSkipsAllGivenPathsInRectorConfig(): void
+    {
+        $this->createRectorConfig(
+            static function (Config\RectorConfig $rectorConfig) {
+                $subject = Src\Config\Config::create($rectorConfig);
+                $subject->not('foo', 'baz');
+                $subject->apply();
+            },
+        );
+
+        $actual = $this->container?->getParameter(Core\Configuration\Option::SKIP);
+
+        self::assertIsArray($actual);
+        self::assertGreaterThanOrEqual(2, count($actual));
+        self::assertSame('foo', $actual[0]);
+        self::assertSame('baz', $actual[1]);
     }
 
     #[Framework\Attributes\Test]


### PR DESCRIPTION
This PR adds a `Config::not()` method which allows to skip paths from Rector config.-