### PR TITLE
[FEATURE] Allow configuration of used PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,17 @@ composer require --dev eliashaeussler/rector-config
 use EliasHaeussler\RectorConfig\Config\Config;
 use EliasHaeussler\RectorConfig\Set\CustomSet;
 use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersion;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Set\ValueObject\SetList;
 
 return static function (RectorConfig $rectorConfig): void {
-    $config = Config::create($rectorConfig)->in(
+    // Optional: Configure PHP version explicitly
+    // Can be left out to use the current environment's PHP version
+    $phpVersion = PhpVersion::PHP_81;
+
+    // Create config from Rector config object
+    $config = Config::create($rectorConfig, $phpVersion)->in(
         __DIR__.'/src',
         __DIR__.'/tests',
     );

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\RectorConfig\Config;
 
+use EliasHaeussler\RectorConfig\Helper\VersionHelper;
 use EliasHaeussler\RectorConfig\Set;
 use Rector\Config as RectorConfig;
 use Rector\Core;
@@ -30,6 +31,7 @@ use Rector\Php73;
 use Rector\Php74;
 
 use function array_values;
+use function is_int;
 
 /**
  * Config.
@@ -66,9 +68,20 @@ final class Config
     ) {
     }
 
-    public static function create(RectorConfig\RectorConfig $rectorConfig): self
-    {
-        return new self($rectorConfig, [new Set\DefaultSet()]);
+    /**
+     * @param non-empty-string|positive-int|null $phpVersion
+     */
+    public static function create(
+        RectorConfig\RectorConfig $rectorConfig,
+        string|int $phpVersion = null,
+    ): self {
+        $phpVersion ??= PHP_VERSION;
+
+        if (is_int($phpVersion)) {
+            $phpVersion = VersionHelper::getVersionFromInteger($phpVersion);
+        }
+
+        return new self($rectorConfig, [new Set\DefaultSet($phpVersion)]);
     }
 
     public function withPHPUnit(): self

--- a/src/Helper/VersionHelper.php
+++ b/src/Helper/VersionHelper.php
@@ -32,6 +32,7 @@ use function defined;
 use function explode;
 use function is_string;
 use function ltrim;
+use function round;
 use function sprintf;
 
 /**
@@ -91,5 +92,19 @@ final class VersionHelper
         }
 
         return null;
+    }
+
+    /**
+     * @param positive-int $versionId
+     *
+     * @return non-empty-string
+     */
+    public static function getVersionFromInteger(int $versionId): string
+    {
+        $major = round($versionId / 10000, 0, PHP_ROUND_HALF_DOWN);
+        $minor = round(($versionId - $major * 10000) / 100, 0, PHP_ROUND_HALF_DOWN);
+        $patch = ($versionId - $major * 10000 - $minor * 100);
+
+        return sprintf('%d.%d.%d', $major, $minor, $patch);
     }
 }

--- a/src/Set/DefaultSet.php
+++ b/src/Set/DefaultSet.php
@@ -34,6 +34,14 @@ use Rector\Set as RectorSet;
  */
 final class DefaultSet implements Set
 {
+    /**
+     * @param non-empty-string $phpVersion
+     */
+    public function __construct(
+        private readonly string $phpVersion = PHP_VERSION,
+    ) {
+    }
+
     public function get(): array
     {
         $set = [
@@ -42,7 +50,7 @@ final class DefaultSet implements Set
 
         // Determine level set list
         $levelSetList = Helper\VersionHelper::getRectorLevelSetListForPackage(
-            PHP_VERSION,
+            $this->phpVersion,
             RectorSet\ValueObject\LevelSetList::class,
             'UP_TO_PHP_%d',
         );

--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\RectorConfig\Tests\Config;
 
 use EliasHaeussler\RectorConfig as Src;
 use EliasHaeussler\RectorConfig\Tests;
+use Generator;
 use PHPUnit\Framework;
 use Rector\CodeQuality;
 use Rector\Config;
@@ -56,6 +57,27 @@ final class ConfigTest extends Framework\TestCase
         Src\Config\Config::create($rectorConfig);
 
         self::assertSame([], $this->container?->getParameter(Core\Configuration\Option::SKIP));
+    }
+
+    /**
+     * @param non-empty-string|positive-int $phpVersion
+     * @param positive-int                  $expected
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('createCanHandleCustomPHPVersionDataProvider')]
+    public function createCanHandleCustomPHPVersion(string|int $phpVersion, int $expected): void
+    {
+        $this->createRectorConfig(
+            static function (Config\RectorConfig $rectorConfig) use ($phpVersion) {
+                $subject = Src\Config\Config::create($rectorConfig, $phpVersion);
+                $subject->apply();
+            },
+        );
+
+        self::assertSame(
+            $expected,
+            $this->container?->getParameter(Core\Configuration\Option::PHP_VERSION_FEATURES),
+        );
     }
 
     #[Framework\Attributes\Test]
@@ -288,6 +310,15 @@ final class ConfigTest extends Framework\TestCase
             ],
             $this->container?->getParameter(Core\Configuration\Option::SKIP),
         );
+    }
+
+    /**
+     * @return Generator<string, array{non-empty-string|positive-int, positive-int}>
+     */
+    public static function createCanHandleCustomPHPVersionDataProvider(): Generator
+    {
+        yield 'version string' => ['8.2.0', Core\ValueObject\PhpVersion::PHP_82];
+        yield 'version id' => [Core\ValueObject\PhpVersion::PHP_82, Core\ValueObject\PhpVersion::PHP_82];
     }
 
     protected function tearDown(): void

--- a/tests/src/Helper/VersionHelperTest.php
+++ b/tests/src/Helper/VersionHelperTest.php
@@ -27,6 +27,8 @@ use EliasHaeussler\RectorConfig as Src;
 use PHPUnit\Framework;
 use Rector\PHPUnit;
 
+use function explode;
+
 /**
  * VersionHelperTest.
  *
@@ -76,5 +78,17 @@ final class VersionHelperTest extends Framework\TestCase
                 'UP_TO_PHPUNIT_%d',
             ),
         );
+    }
+
+    #[Framework\Attributes\Test]
+    public function getVersionFromIntegerConvertsVersionIdToVersion(): void
+    {
+        $actual = Src\Helper\VersionHelper::getVersionFromInteger(PHP_VERSION_ID);
+        $versionNumbers = explode('.', $actual);
+
+        self::assertCount(3, $versionNumbers);
+        self::assertSame(PHP_MAJOR_VERSION, (int) $versionNumbers[0]);
+        self::assertSame(PHP_MINOR_VERSION, (int) $versionNumbers[1]);
+        self::assertSame(PHP_RELEASE_VERSION, (int) $versionNumbers[2]);
     }
 }

--- a/tests/src/Set/DefaultSetTest.php
+++ b/tests/src/Set/DefaultSetTest.php
@@ -26,6 +26,8 @@ namespace EliasHaeussler\RectorConfig\Tests\Set;
 use EliasHaeussler\RectorConfig as Src;
 use PHPUnit\Framework;
 
+use function sprintf;
+
 /**
  * DefaultSetTest.
  *
@@ -42,11 +44,25 @@ final class DefaultSetTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function constructorAllowsConfiguringPHPVersion(): void
+    {
+        $subject = new Src\Set\DefaultSet('8.2.0');
+
+        $actual = $subject->get();
+
+        self::assertCount(2, $actual);
+        self::assertMatchesRegularExpression('/config\\/set\\/level\\/up-to-php82\\.php$/', $actual[1]);
+    }
+
+    #[Framework\Attributes\Test]
     public function getReturnsDefaultSetWithLevelSetList(): void
     {
         $actual = $this->subject->get();
 
         self::assertCount(2, $actual);
-        self::assertMatchesRegularExpression('/config\\/set\\/level\\/up-to-php8\\d+\\.php$/', $actual[1]);
+        self::assertMatchesRegularExpression(
+            sprintf('/config\\/set\\/level\\/up-to-php%d%d\\.php$/', PHP_MAJOR_VERSION, PHP_MINOR_VERSION),
+            $actual[1],
+        );
     }
 }


### PR DESCRIPTION
This PR allows to configure the PHP version to be used when running Rector migrations. It can be left out to use the current environment's PHP version (which is the current default behavior).