### PR TITLE
[FEATURE] Allow fallback to previous versions for level set lists

### DIFF
--- a/src/Set/SymfonySet.php
+++ b/src/Set/SymfonySet.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\RectorConfig\Set;
 
+use EliasHaeussler\RectorConfig\Enums;
 use EliasHaeussler\RectorConfig\Exception;
 use EliasHaeussler\RectorConfig\Helper;
 use Rector\Symfony;
@@ -70,6 +71,8 @@ final class SymfonySet implements Set
             $this->symfonyVersion,
             Symfony\Set\SymfonyLevelSetList::class,
             'UP_TO_SYMFONY_%d',
+            Enums\VersionRange::MajorMinor,
+            true,
         );
 
         // Add level set list, if available

--- a/tests/src/Helper/VersionHelperTest.php
+++ b/tests/src/Helper/VersionHelperTest.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\RectorConfig\Tests\Helper;
 use EliasHaeussler\RectorConfig as Src;
 use PHPUnit\Framework;
 use Rector\PHPUnit;
+use Rector\Symfony;
 
 use function explode;
 
@@ -54,6 +55,18 @@ final class VersionHelperTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function getRectorLevelSetListForPackageReturnsNullOnInvalidPackageVersion(): void
+    {
+        self::assertNull(
+            Src\Helper\VersionHelper::getRectorLevelSetListForPackage(
+                'foo',
+                PHPUnit\Set\PHPUnitLevelSetList::class,
+                'UP_TO_PHPUNIT_%d',
+            ),
+        );
+    }
+
+    #[Framework\Attributes\Test]
     public function getRectorLevelSetListForPackageReturnsLevelSetList(): void
     {
         $expected = PHPUnit\Set\PHPUnitLevelSetList::UP_TO_PHPUNIT_100;
@@ -76,6 +89,37 @@ final class VersionHelperTest extends Framework\TestCase
                 '1.0.0',
                 PHPUnit\Set\PHPUnitLevelSetList::class,
                 'UP_TO_PHPUNIT_%d',
+            ),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function getRectorLevelSetListForPackageReturnsLevelSetListForPreviousVersion(): void
+    {
+        $expected = Symfony\Set\SymfonyLevelSetList::UP_TO_SYMFONY_54;
+
+        self::assertSame(
+            $expected,
+            Src\Helper\VersionHelper::getRectorLevelSetListForPackage(
+                '5.99.99',
+                Symfony\Set\SymfonyLevelSetList::class,
+                'UP_TO_SYMFONY_%d',
+                Src\Enums\VersionRange::MajorMinor,
+                true,
+            ),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function getRectorLevelSetListForPackageReturnsNUllIfNoPreviousVersionExists(): void
+    {
+        self::assertNull(
+            Src\Helper\VersionHelper::getRectorLevelSetListForPackage(
+                '2.1.0',
+                PHPUnit\Set\PHPUnitLevelSetList::class,
+                'UP_TO_PHPUNIT_%d',
+                Src\Enums\VersionRange::MajorMinor,
+                true,
             ),
         );
     }


### PR DESCRIPTION
This PR extends `VersionHelper::getRectorLevelSetListForPackage()` with a new parameter. It allows to resolve the given level set list with any previous version, if no level set list exists for the given package version.