### PR TITLE
[BUGFIX] Remove usage of PHPUNIT_YIELD_DATA_PROVIDER

### DIFF
--- a/src/Set/PHPUnitSet.php
+++ b/src/Set/PHPUnitSet.php
@@ -56,7 +56,6 @@ final class PHPUnitSet implements Set
         $set = [
             PHPUnit\Set\PHPUnitSetList::PHPUNIT_EXCEPTION,
             PHPUnit\Set\PHPUnitSetList::PHPUNIT_SPECIFIC_METHOD,
-            PHPUnit\Set\PHPUnitSetList::PHPUNIT_YIELD_DATA_PROVIDER,
         ];
 
         // Add PHPUnit 10.x sets

--- a/tests/e2e/src/test-files/phpunit-set.php
+++ b/tests/e2e/src/test-files/phpunit-set.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
@@ -69,27 +68,5 @@ final class PHPUnitSpecificMethodSetListTestClass extends TestCase
         $foo = false;
 
         self::assertTrue(!$foo);
-    }
-}
-
-/**
- * This class should convert array data providers to yield data providers.
- *
- * @see \Rector\PHPUnit\Set\PHPUnitSetList::PHPUNIT_YIELD_DATA_PROVIDER
- */
-final class PHPUnitYieldDataProviderSetListTestClass extends TestCase
-{
-    #[Test]
-    #[DataProvider('provider')]
-    public function testCase(string $foo): void
-    {
-    }
-
-    /**
-     * @return array<string, array{string}>
-     */
-    public static function provider(): array
-    {
-        return ['foo' => ['baz']];
     }
 }

--- a/tests/src/Set/PHPUnitSetTest.php
+++ b/tests/src/Set/PHPUnitSetTest.php
@@ -46,10 +46,10 @@ final class PHPUnitSetTest extends Framework\TestCase
     {
         $actual = $this->subject->get();
 
-        self::assertCount(5, $actual);
+        self::assertCount(4, $actual);
         self::assertMatchesRegularExpression(
             '/config\\/sets\\/level\\/up-to-phpunit-10\\d+\\.php$/',
-            $actual[4],
+            $actual[3],
         );
     }
 }


### PR DESCRIPTION
The `PHPUNIT_YIELD_DATA_PROVIDER` constant has been removed in Rector 0.17.0. Thus, it can no longer be used.