### PR TITLE
[BUGFIX] Skip test if level set list for PHP version is not defined

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1548,30 +1548,30 @@
         },
         {
             "name": "eliashaeussler/php-cs-fixer-config",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/eliashaeussler/php-cs-fixer-config.git",
-                "reference": "70352427c7e4a5951e3bd04152dc62814907f38d"
+                "reference": "6cfffbbaa4ac2713e52b0ca1f0a9b86bbdbfffa8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/eliashaeussler/php-cs-fixer-config/zipball/70352427c7e4a5951e3bd04152dc62814907f38d",
-                "reference": "70352427c7e4a5951e3bd04152dc62814907f38d",
+                "url": "https://api.github.com/repos/eliashaeussler/php-cs-fixer-config/zipball/6cfffbbaa4ac2713e52b0ca1f0a9b86bbdbfffa8",
+                "reference": "6cfffbbaa4ac2713e52b0ca1f0a9b86bbdbfffa8",
                 "shasum": ""
             },
             "require": {
                 "friendsofphp/php-cs-fixer": "^3.14",
-                "php": "~8.1.0 || ~8.2.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
                 "symfony/finder": "^5.4 || ^6.0"
             },
             "require-dev": {
                 "armin/editorconfig-cli": "^1.5",
-                "eliashaeussler/phpstan-config": "^1.0.1",
+                "eliashaeussler/phpstan-config": "^2.0.0",
                 "ergebnis/composer-normalize": "^2.29",
                 "phpstan/extension-installer": "^1.2",
-                "phpunit/phpunit": "^10.0",
-                "rector/rector": "^0.15.17"
+                "phpunit/phpunit": "^10.1",
+                "rector/rector": "^0.18.0"
             },
             "type": "library",
             "autoload": {
@@ -1594,26 +1594,26 @@
             "description": "My personal configuration for PHP-CS-Fixer",
             "support": {
                 "issues": "https://github.com/eliashaeussler/php-cs-fixer-config/issues",
-                "source": "https://github.com/eliashaeussler/php-cs-fixer-config/tree/1.2.0"
+                "source": "https://github.com/eliashaeussler/php-cs-fixer-config/tree/1.3.0"
             },
-            "time": "2023-03-14T21:22:18+00:00"
+            "time": "2023-10-30T21:27:50+00:00"
         },
         {
             "name": "eliashaeussler/phpstan-config",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/eliashaeussler/phpstan-config.git",
-                "reference": "cbfe5e5c23c5c2a91bd00a8917c9c9171cc3a5a0"
+                "reference": "9d0939ce61dae5ae465f715381499375dfb1c004"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/eliashaeussler/phpstan-config/zipball/cbfe5e5c23c5c2a91bd00a8917c9c9171cc3a5a0",
-                "reference": "cbfe5e5c23c5c2a91bd00a8917c9c9171cc3a5a0",
+                "url": "https://api.github.com/repos/eliashaeussler/phpstan-config/zipball/9d0939ce61dae5ae465f715381499375dfb1c004",
+                "reference": "9d0939ce61dae5ae465f715381499375dfb1c004",
                 "shasum": ""
             },
             "require": {
-                "php": "~8.1.0 || ~8.2.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
                 "phpstan/phpstan": "^1.9",
                 "phpstan/phpstan-deprecation-rules": "^1.1",
                 "phpstan/phpstan-strict-rules": "^1.4"
@@ -1653,9 +1653,9 @@
             "description": "My personal configuration for PHPStan",
             "support": {
                 "issues": "https://github.com/eliashaeussler/phpstan-config/issues",
-                "source": "https://github.com/eliashaeussler/phpstan-config/tree/2.2.0"
+                "source": "https://github.com/eliashaeussler/phpstan-config/tree/2.3.0"
             },
-            "time": "2023-09-20T18:54:56+00:00"
+            "time": "2023-10-30T21:34:43+00:00"
         },
         {
             "name": "enshrined/svg-sanitize",
@@ -9747,5 +9747,5 @@
         "composer-runtime-api": "^2.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/tests/src/Set/DefaultSetTest.php
+++ b/tests/src/Set/DefaultSetTest.php
@@ -25,7 +25,9 @@ namespace EliasHaeussler\RectorConfig\Tests\Set;
 
 use EliasHaeussler\RectorConfig as Src;
 use PHPUnit\Framework;
+use Rector\Set;
 
+use function defined;
 use function sprintf;
 
 /**
@@ -57,6 +59,17 @@ final class DefaultSetTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function getReturnsDefaultSetWithLevelSetList(): void
     {
+        $levelSetList = sprintf(
+            '%s::UP_TO_PHP_%d%d',
+            Set\ValueObject\LevelSetList::class,
+            PHP_MAJOR_VERSION,
+            PHP_MINOR_VERSION,
+        );
+
+        if (!defined($levelSetList)) {
+            self::markTestSkipped('Level set list does not exist for this PHP version.');
+        }
+
         $actual = $this->subject->get();
 
         self::assertCount(2, $actual);


### PR DESCRIPTION
This PR skips a test case if the appropriate level set list for the current PHP version is not defined.