### PR TITLE
[TASK] Add `#[CoversClass()]` attributes to all Unit tests

### DIFF
--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -45,6 +45,7 @@ use function count;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Config\Config::class)]
 final class ConfigTest extends Framework\TestCase
 {
     use Tests\RectorConfigTrait;

--- a/tests/src/Entity/VersionTest.php
+++ b/tests/src/Entity/VersionTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Entity\Version::class)]
 final class VersionTest extends Framework\TestCase
 {
     private Src\Entity\Version $subject;

--- a/tests/src/Exception/RequiredPackageIsMissingTest.php
+++ b/tests/src/Exception/RequiredPackageIsMissingTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Exception\RequiredPackageIsMissing::class)]
 final class RequiredPackageIsMissingTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/src/Exception/VersionStringIsInvalidTest.php
+++ b/tests/src/Exception/VersionStringIsInvalidTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Exception\VersionStringIsInvalid::class)]
 final class VersionStringIsInvalidTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/src/Helper/VersionHelperTest.php
+++ b/tests/src/Helper/VersionHelperTest.php
@@ -34,6 +34,7 @@ use Rector\Symfony;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Helper\VersionHelper::class)]
 final class VersionHelperTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/src/Set/CustomSetTest.php
+++ b/tests/src/Set/CustomSetTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Set\CustomSet::class)]
 final class CustomSetTest extends Framework\TestCase
 {
     private Src\Set\CustomSet $subject;

--- a/tests/src/Set/DefaultSetTest.php
+++ b/tests/src/Set/DefaultSetTest.php
@@ -36,6 +36,7 @@ use function sprintf;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Set\DefaultSet::class)]
 final class DefaultSetTest extends Framework\TestCase
 {
     private Src\Set\DefaultSet $subject;

--- a/tests/src/Set/PHPUnitSetTest.php
+++ b/tests/src/Set/PHPUnitSetTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Set\PHPUnitSet::class)]
 final class PHPUnitSetTest extends Framework\TestCase
 {
     private Src\Set\PHPUnitSet $subject;

--- a/tests/src/Set/SymfonySetTest.php
+++ b/tests/src/Set/SymfonySetTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Set\SymfonySet::class)]
 final class SymfonySetTest extends Framework\TestCase
 {
     private Src\Set\SymfonySet $subject;

--- a/tests/src/Set/TYPO3SetTest.php
+++ b/tests/src/Set/TYPO3SetTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Set\TYPO3Set::class)]
 final class TYPO3SetTest extends Framework\TestCase
 {
     private Src\Set\TYPO3Set $subject;


### PR DESCRIPTION
This PR adds a `#[CoversClass()]` attribute to all Unit tests.