### PR TITLE
[BUGFIX] Remove no longer used Rector rules from skipped rectors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require": {
 		"php": "~8.1.0 || ~8.2.0 || ~8.3.0",
 		"composer-runtime-api": "^2.0",
-		"rector/rector": "^1.0"
+		"rector/rector": "^1.2"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^1.8 || ^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e687155c2233d61b3b3829867ce416ae",
+    "content-hash": "104f336fef3f4e7a9ab94e836300d72d",
     "packages": [
         {
             "name": "phpstan/phpstan",

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -28,8 +28,6 @@ use EliasHaeussler\RectorConfig\Exception;
 use EliasHaeussler\RectorConfig\Set;
 use Rector\Config as RectorConfig;
 use Rector\Contract;
-use Rector\Php73;
-use Rector\Php74;
 use Rector\PHPUnit;
 use Rector\ValueObject;
 
@@ -64,9 +62,6 @@ final class Config
      * @var array<class-string<Contract\Rector\RectorInterface>, list<non-empty-string>>
      */
     private array $skippedRectors = [
-        Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector::class => [],
-        Php73\Rector\FuncCall\JsonThrowOnErrorRector::class => [],
-        PHPUnit\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector::class => [],
         PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class => [],
         PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector::class => [],
     ];

--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -30,7 +30,6 @@ use PHPUnit\Framework;
 use Rector\CodeQuality;
 use Rector\Config;
 use Rector\Configuration;
-use Rector\Php73;
 use Rector\Php74;
 use Rector\PHPUnit;
 use Rector\Set;
@@ -94,9 +93,6 @@ final class ConfigTest extends Framework\TestCase
 
         self::assertSame(
             [
-                Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector::class,
-                Php73\Rector\FuncCall\JsonThrowOnErrorRector::class,
-                PHPUnit\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector::class,
                 PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
                 PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector::class,
             ],
@@ -304,9 +300,6 @@ final class ConfigTest extends Framework\TestCase
 
         self::assertSame(
             [
-                Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector::class,
-                Php73\Rector\FuncCall\JsonThrowOnErrorRector::class,
-                PHPUnit\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector::class,
                 PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
                 PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector::class,
                 Php74\Rector\Closure\ClosureToArrowFunctionRector::class,
@@ -328,9 +321,6 @@ final class ConfigTest extends Framework\TestCase
 
         self::assertSame(
             [
-                Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector::class,
-                Php73\Rector\FuncCall\JsonThrowOnErrorRector::class,
-                PHPUnit\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector::class,
                 PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
                 PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector::class,
                 Php74\Rector\Closure\ClosureToArrowFunctionRector::class => ['foo', 'baz'],
@@ -353,9 +343,6 @@ final class ConfigTest extends Framework\TestCase
 
         self::assertSame(
             [
-                Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector::class,
-                Php73\Rector\FuncCall\JsonThrowOnErrorRector::class,
-                PHPUnit\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector::class,
                 PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
                 PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector::class,
                 Php74\Rector\Closure\ClosureToArrowFunctionRector::class => ['foo', 'baz'],
@@ -378,9 +365,6 @@ final class ConfigTest extends Framework\TestCase
 
         self::assertSame(
             [
-                Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector::class,
-                Php73\Rector\FuncCall\JsonThrowOnErrorRector::class,
-                PHPUnit\CodeQuality\Rector\Class_\AddSeeTestAnnotationRector::class,
                 PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
                 PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector::class,
                 Php74\Rector\Closure\ClosureToArrowFunctionRector::class => ['baz'],


### PR DESCRIPTION
Rector v1.2.0 removed some Rector rules from default config. Since we skipped some of those rules, it's no longer relevant to skip them.