### PR TITLE
[BUGFIX] Skip `NarrowUnusedSetUpDefinedPropertyRector` by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
 	"require": {
 		"php": "~8.1.0 || ~8.2.0 || ~8.3.0",
 		"composer-runtime-api": "^2.0",
-		"rector/rector": "^1.2"
+		"rector/rector": "^1.2.9"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^1.8 || ^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "98f3dc64446550d81fb30fbfac0594b9",
+    "content-hash": "afbb51f4ee7b9d8d53815e4dd177e5dd",
     "packages": [
         {
             "name": "phpstan/phpstan",
@@ -10074,13 +10074,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "composer-runtime-api": "^2.0"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -62,6 +62,7 @@ final class Config
      * @var array<class-string<Contract\Rector\RectorInterface>, list<non-empty-string>>
      */
     private array $skippedRectors = [
+        PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector::class => [],
         PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class => [],
         PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector::class => [],
     ];

--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -94,6 +94,7 @@ final class ConfigTest extends Framework\TestCase
 
         self::assertSame(
             [
+                PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector::class,
                 PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
                 PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector::class,
             ],
@@ -295,6 +296,7 @@ final class ConfigTest extends Framework\TestCase
 
         self::assertSame(
             [
+                PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector::class,
                 PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
                 PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector::class,
                 Php74\Rector\Closure\ClosureToArrowFunctionRector::class,
@@ -316,6 +318,7 @@ final class ConfigTest extends Framework\TestCase
 
         self::assertSame(
             [
+                PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector::class,
                 PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
                 PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector::class,
                 Php74\Rector\Closure\ClosureToArrowFunctionRector::class => ['foo', 'baz'],
@@ -338,6 +341,7 @@ final class ConfigTest extends Framework\TestCase
 
         self::assertSame(
             [
+                PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector::class,
                 PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
                 PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector::class,
                 Php74\Rector\Closure\ClosureToArrowFunctionRector::class => ['foo', 'baz'],
@@ -360,6 +364,7 @@ final class ConfigTest extends Framework\TestCase
 
         self::assertSame(
             [
+                PHPUnit\CodeQuality\Rector\Class_\NarrowUnusedSetUpDefinedPropertyRector::class,
                 PHPUnit\CodeQuality\Rector\Class_\PreferPHPUnitThisCallRector::class,
                 PHPUnit\CodeQuality\Rector\ClassMethod\ReplaceTestAnnotationWithPrefixedFunctionRector::class,
                 Php74\Rector\Closure\ClosureToArrowFunctionRector::class => ['baz'],


### PR DESCRIPTION
The newly introduced `NarrowUnusedSetUpDefinedPropertyRector` causes issues within TYPO3 functional tests. In addition, it does not serve any greater purpose, because such issues would be detected by PHPStan as well. Therefore, the rector rule is skipped by default.