### PR TITLE
[TASK] Convert markTestSkipped method call to RequiresPackage attribute

### DIFF
--- a/tests/src/Config/ConfigTest.php
+++ b/tests/src/Config/ConfigTest.php
@@ -28,7 +28,6 @@ use EliasHaeussler\RectorConfig as Src;
 use EliasHaeussler\RectorConfig\Tests;
 use Generator;
 use PHPUnit\Framework;
-use PHPUnit\Runner;
 use Rector\CodeQuality;
 use Rector\Config;
 use Rector\Configuration;
@@ -122,6 +121,7 @@ final class ConfigTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    #[PHPUnitAttributes\Attribute\RequiresPackage('phpunit/phpunit', '10')]
     public function withPHPUnitImportsPHPUnitSetListInRectorConfig(): void
     {
         $this->createRectorConfig(
@@ -132,13 +132,7 @@ final class ConfigTest extends Framework\TestCase
             },
         );
 
-        $expected = match (Runner\Version::majorVersionNumber()) {
-            /* @see PHPUnit\Set\PHPUnitSetList::PHPUNIT_100 */
-            10 => PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector::class,
-            default => self::markTestSkipped('PHPUnit version is not supported yet.'),
-        };
-
-        self::assertTrue($this->container?->has($expected));
+        self::assertTrue($this->container?->has(PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector::class));
     }
 
     #[Framework\Attributes\Test]


### PR DESCRIPTION
This pull request includes updates to the `tests/src/Config/ConfigTest.php` file to ensure compatibility with PHPUnit version 10. The most important changes are the addition of a new attribute to require PHPUnit 10 and the simplification of the version check logic.

Updates for PHPUnit 10 compatibility:

* [`tests/src/Config/ConfigTest.php`](diffhunk://#diff-79b61fbf362a0ccc21e6cabc3dff52bc2315ddba203af00150d8f7213fe0c816R125): Added `#[PHPUnitAttributes\Attribute\RequiresPackage('phpunit/phpunit', '10')]` to require PHPUnit version 10 for the test method `withPHPUnitImportsPHPUnitSetListInRectorConfig`.
* [`tests/src/Config/ConfigTest.php`](diffhunk://#diff-79b61fbf362a0ccc21e6cabc3dff52bc2315ddba203af00150d8f7213fe0c816L135-R136): Simplified the version check logic by removing the `match` statement and directly asserting the presence of `PHPUnit\PHPUnit100\Rector\Class_\StaticDataProviderClassMethodRector::class`.