### PR TITLE
[BUGFIX] Add assertion for TYPO3 v14, drop assertion for TYPO3 v12

### DIFF
--- a/tests/unit/Config/ConfigTest.php
+++ b/tests/unit/Config/ConfigTest.php
@@ -233,8 +233,8 @@ final class ConfigTest extends Framework\TestCase
     public function withTYPO3AddsAdditionalTYPO3RulesToRectorConfig(): void
     {
         $expected = match ((new Core\Information\Typo3Version())->getMajorVersion()) {
-            12 => TYPO3Rector\TYPO312\v0\MigrateColsToSizeForTcaTypeNoneRector::class,
             13 => TYPO3Rector\TYPO313\v0\AddMethodGetAllPageNumbersToPaginationInterfaceRector::class,
+            14 => TYPO3Rector\TYPO314\v0\MigrateSingleDataStructureConfigurationRector::class,
             default => self::markTestSkipped('TYPO3 version is not supported.'),
         };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated configuration tests to validate the expected rules for the latest supported TYPO3 version.
  * Removed outdated expectations for TYPO3 12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->